### PR TITLE
Exclude migrations folder from the maintainability duplications checks

### DIFF
--- a/codeclimate.yml
+++ b/codeclimate.yml
@@ -62,3 +62,4 @@ exclude_patterns:
 - "**/tests/"
 - "**/vendor/"
 - "**/*.d.ts"
+- "**/migrations/"


### PR DESCRIPTION
Excluding Migrations in the Duplication Checks